### PR TITLE
Add Whitelist UI and Global Enable/Disable Feature

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,12 @@
   "icons": {
     "128": "icon128.png"
   },
-  "permissions": ["tabs"],
-  "host_permissions": ["https://*/*", "http://*/*"]
+  "permissions": ["tabs", "storage"],
+  "host_permissions": ["https://*/*", "http://*/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "128": "icon128.png"
+    }
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,7 @@
   "manifest_version": 3,
   "icons": {
     "128": "icon128.png"
-  }
+  },
+  "permissions": ["tabs"],
+  "host_permissions": ["https://*/*", "http://*/*"]
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Zoom Per Tab Settings</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        min-width: 220px;
+      }
+      .domain {
+        font-weight: bold;
+      }
+      .btn {
+        margin: 8px 0;
+        padding: 6px 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <label>
+        <input type="checkbox" id="globalToggle" />
+        Enable extension
+      </label>
+    </div>
+    <hr />
+    <div>
+      <span class="domain" id="currentDomain">Checking domain...</span>
+      <button class="btn" id="toggleDomainBtn">Add/Remove</button>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,56 @@
+// popup.js
+function getDomain(url) {
+  try {
+    const u = new URL(url);
+    return u.origin;
+  } catch {
+    return null;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const domain = tab && tab.url ? getDomain(tab.url) : null;
+  const domainSpan = document.getElementById("currentDomain");
+  const toggleBtn = document.getElementById("toggleDomainBtn");
+  const globalToggle = document.getElementById("globalToggle");
+
+  // Read state from storage
+  chrome.storage.sync.get(["whitelist", "enabled"], (data) => {
+    const whitelist = data.whitelist || [];
+    const enabled = data.enabled !== false; // Default: true
+    globalToggle.checked = enabled;
+
+    if (domain) {
+      domainSpan.textContent = domain;
+      toggleBtn.textContent = whitelist.includes(domain)
+        ? "Remove from whitelist"
+        : "Add to whitelist";
+      toggleBtn.disabled = false;
+    } else {
+      domainSpan.textContent = "Invalid page";
+      toggleBtn.disabled = true;
+    }
+  });
+
+  // Add/remove domain
+  toggleBtn.onclick = () => {
+    chrome.storage.sync.get(["whitelist"], (data) => {
+      let whitelist = data.whitelist || [];
+      if (!domain) return;
+      if (whitelist.includes(domain)) {
+        whitelist = whitelist.filter((d) => d !== domain);
+      } else {
+        whitelist.push(domain);
+      }
+      chrome.storage.sync.set({ whitelist }, () => {
+        window.location.reload();
+      });
+    });
+  };
+
+  // Enable/disable extension
+  globalToggle.onchange = () => {
+    chrome.storage.sync.set({ enabled: globalToggle.checked });
+  };
+});

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,3 +1,12 @@
+// 화이트리스트 도메인 배열
+const whitelist = ["https://github.com"];
+
 chrome.tabs.onZoomChange.addListener((zoomChangeInfo) => {
-	chrome.tabs.setZoomSettings(zoomChangeInfo.tabId, { scope: "per-tab" });
+  chrome.tabs.get(zoomChangeInfo.tabId, (tab) => {
+    if (!tab || !tab.url) return;
+    // whitelist에 포함된 도메인으로 시작하는지 확인
+    if (whitelist.some((domain) => tab.url.startsWith(domain))) {
+      chrome.tabs.setZoomSettings(zoomChangeInfo.tabId, { scope: "per-tab" });
+    }
+  });
 });


### PR DESCRIPTION
Huge thanks for building and open-sourcing this amazing project.
It’s been a pleasure to use, and I’m excited to contribute something back!

![image](https://github.com/user-attachments/assets/f06bf1e9-f3e8-448d-aacd-9769ecdf9132)

### Summary

This PR introduces a popup UI for managing a whitelist of domains and a global enable/disable toggle for the extension.

### Changes

- **Whitelist UI**: Added a popup (popup.html, popup.js) that allows users to add or remove the current domain from a whitelist. Only whitelisted domains will have per-tab zoom applied.
- **Global Enable/Disable**: Added a toggle in the popup to enable or disable the extension’s functionality without uninstalling.
- **Persistent Settings**: Whitelist and enable/disable state are saved using Chrome storage and persist across browser restarts.
- **Manifest Update**: Updated manifest.json to register the popup and required permissions.

### Usage

1. Click the extension icon to open the popup.
2. Use the toggle to enable or disable the extension globally.
3. Use the button to add or remove the current domain from the whitelist.
4. Only whitelisted domains will have per-tab zoom enforced.

